### PR TITLE
Support standalone binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +429,12 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "flagset"
@@ -663,6 +679,7 @@ dependencies = [
  "rustc-hash",
  "stardust-xr-fusion",
  "stardust-xr-molecules",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -699,6 +716,12 @@ dependencies = [
  "libc",
  "redox_syscall 0.4.1",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1245,6 +1268,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1544,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ color-rs = "0.8.0"
 colorgrad = "0.6.2"
 map-range = "0.1.2"
 clap = { version = "4.5.0", features = ["derive"] }
+tempfile = "3.10.1"
 
 [dependencies.stardust-xr-fusion]
 git = "https://github.com/StardustXR/core.git"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,19 @@ pub mod ring;
 use crate::kiara::Kiara;
 use clap::Parser;
 use color_eyre::eyre::{bail, Result};
-use manifest_dir_macros::{directory_relative_path, file_relative_path};
 use stardust_xr_fusion::{client::Client, items::ItemUI};
 use std::env::set_var;
 use tokio::process::Command;
 use tracing_subscriber::EnvFilter;
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+	static ref RING_GLB: Vec<u8> = include_bytes!("../res/kiara/ring.glb").to_vec();
+	static ref KIARA_BLEND: Vec<u8> = include_bytes!("../assets/kiara.blend").to_vec();
+	static ref KIARA_BLEND1: Vec<u8> = include_bytes!("../assets/kiara.blend1").to_vec();
+	static ref NIRI_CONFIG_KDL: Vec<u8> = include_bytes!("../src/niri_config.kdl").to_vec();
+}
 
 #[derive(Debug, clap::Parser)]
 pub struct Cli {
@@ -18,13 +26,24 @@ pub struct Cli {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
+	// Make temporary directory for resources and copy resources to it
+	let temp_dir = tempfile::tempdir().unwrap();
+	let temp_dir_path = temp_dir.path().to_str().unwrap();
+	std::fs::create_dir_all(format!("{}/res/kiara", temp_dir_path)).expect("Failed to create res/kiara directory");
+	std::fs::create_dir_all(format!("{}/assets", temp_dir_path)).expect("Failed to create assets directory");
+	std::fs::create_dir_all(format!("{}/src", temp_dir_path)).expect("Failed to create src directory");
+	std::fs::write(format!("{}/res/kiara/ring.glb", temp_dir_path), &*RING_GLB).expect("Failed to write ring.glb");
+	std::fs::write(format!("{}/assets/kiara.blend", temp_dir_path), &*KIARA_BLEND).expect("Failed to write kiara.blend");
+	std::fs::write(format!("{}/assets/kiara.blend1", temp_dir_path), &*KIARA_BLEND1).expect("Failed to write kiara.blend1");
+	std::fs::write(format!("{}/src/niri_config.kdl", temp_dir_path), &*NIRI_CONFIG_KDL).expect("Failed to write niri_config.kdl");
+
 	tracing_subscriber::fmt()
 		.compact()
 		.with_env_filter(EnvFilter::from_env("LOG_LEVEL"))
 		.init();
 	let args = Cli::parse();
 	let (client, event_loop) = Client::connect_with_async_loop().await?;
-	client.set_base_prefixes(&[directory_relative_path!("res")]);
+	client.set_base_prefixes(&[format!("{}/res", temp_dir_path).as_str()]);
 
 	let kiara = client.wrap_root(Kiara::new())?;
 	let _item_ui_wrapped = ItemUI::register(&client)?.wrap_raw(kiara)?;
@@ -33,7 +52,7 @@ async fn main() -> Result<()> {
 		set_var(key, value);
 	}
 	let mut niri_open = Command::new("niri")
-		.args(&["-c", file_relative_path!("src/niri_config.kdl"), "--"])
+		.args(&["-c", format!("{}/src/niri_config.kdl", temp_dir_path).as_str(), "--"])
 		.args(&args.niri_launch)
 		.spawn()?;
 


### PR DESCRIPTION
This allows the binary to work portably, as long as `niri` is in `$PATH`.